### PR TITLE
Remove extranouus pasted ;'s

### DIFF
--- a/lib/progress.h
+++ b/lib/progress.h
@@ -44,9 +44,9 @@ void initializeThreadedProgressRecord(
      void (*progressCallback)(int, void*),
      void * contextInfo,
 #ifdef SYNTH_USE_GLIB_THREADS
-     GMutex *mutexProgress;
+     GMutex *mutexProgress
 #else
-     pthread_mutex_t *mutexProgress;
+     pthread_mutex_t *mutexProgress
 #endif
 );
      


### PR DESCRIPTION
It seems when the glib threading ifdefs were pasted into this file, extraneous semicolons were pasted into the initializeThreaded ProgressRecord function definition. This causes build failures with at least clang version 15.0.7.